### PR TITLE
remove doc of non existing parameter

### DIFF
--- a/tests/system/webdriver/Pages/Content/ArticleManagerPage.php
+++ b/tests/system/webdriver/Pages/Content/ArticleManagerPage.php
@@ -308,7 +308,6 @@ class ArticleManagerPage extends AdminManagerPage
 	 * change the Category Filter from Article Manager Page
 	 *
 	 * @param string $category Name of the Category to which the filter is to be set to
-	 * @param string $searchString to be entered in the filter to select the desired category
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
I was trying to reproduce:

```

3) ArticleManager0001Test::changeArticleState_ChangePublishedUsingToolbar_PublishedChanged
Undefined variable: resultObject

/tests/system/webdriver/SeleniumClient/WebDriverWait.php:62
/tests/system/webdriver/SeleniumClient/WebDriver.php:416
/tests/system/webdriver/Pages/System/AdminManagerPage.php:261
/tests/system/webdriver/Pages/System/AdminManagerPage.php:308
/tests/system/webdriver/tests/content/ArticleManager0001Test.php:192

--
```

found at https://github.com/joomla-projects/GSOC-Webdriver_system_tests_for_CMS/issues/112

However running the test alone I got no error:

```
JAVI:tests javiergomez$ /Applications/XAMPP/xamppfiles/bin/phpunit --verbose content/ArticleManager0001Test.php 
PHPUnit 3.7.29 by Sebastian Bergmann.

Configuration read from tests/system/webdriver/tests/phpunit.xml.dist

........

Time: 4.46 minutes, Memory: 6.25Mb

OK (8 tests, 244 assertions)
```

Anyway I'm sending a couple of fixes in the dockblocs
