### PR TITLE
fix issue in MetaDescription change at frontend

### DIFF
--- a/tests/system/webdriver/tests/services/ConfigFrontEnd0002Test.php
+++ b/tests/system/webdriver/tests/services/ConfigFrontEnd0002Test.php
@@ -76,8 +76,6 @@ class ConfigFrontEnd0002Test extends JoomlaWebdriverTestCase
 	 */
 	public function testChangeMetaDescription()
 	{
-		$this->assertEquals($this->previousMetaDescription, $this->siteHomePage->getMetaDescription(), 'Meta Description not changed');
-
 		$newMetaDescription = 'JoomlaTestMetaDescription' . rand(1,100);
 		$this->siteHomePage->changeMetaDescription($newMetaDescription);
 

--- a/tests/system/webdriver/tests/services/ConfigFrontEnd0002Test.php
+++ b/tests/system/webdriver/tests/services/ConfigFrontEnd0002Test.php
@@ -76,8 +76,11 @@ class ConfigFrontEnd0002Test extends JoomlaWebdriverTestCase
 	 */
 	public function testChangeMetaDescription()
 	{
-		$this->siteHomePage->changeMetaDescription('JoomlaTestMetaDescription');
+		$this->assertEquals($this->previousMetaDescription, $this->siteHomePage->getMetaDescription(), 'Meta Description not changed');
 
-		$this->assertNotEquals('JoomlaTestMetaDescription', $this->siteHomePage->getMetaDescription(), 'Site Meta Description has not changed');
+		$newMetaDescription = 'JoomlaTestMetaDescription' . rand(1,100);
+		$this->siteHomePage->changeMetaDescription($newMetaDescription);
+
+		$this->assertNotEquals($this->previousMetaDescription, $this->siteHomePage->getMetaDescription(), 'Site Meta Description has not changed');
 	}
 }


### PR DESCRIPTION
Fixes the test:

```
phpunit --verbose services/ConfigFrontEnd0002Test.php
PHPUnit 3.7.29 by Sebastian Bergmann.

Configuration read from /Users/javiergomez/Documents/joomla-vagrant/www/repos/GSOC-Webdriver_system_tests_for_CMS/tests/system/webdriver/tests/phpunit.xml.dist

.

Time: 13.88 seconds, Memory: 4.25Mb

OK (1 test, 20 assertions)
```
